### PR TITLE
Improve numba version

### DIFF
--- a/galibrate/run_gao_numba.py
+++ b/galibrate/run_gao_numba.py
@@ -21,11 +21,12 @@ def run_gao(pop_size, n_sp, locs, widths, n_gen,
         fitnesses_idxs_sort = np.sort(fitnesses_idxs, axis=0)
         survivors = fitnesses_idxs_sort[int(pop_size/2):]
         # Move over the survivors
-        #new_chromosome = _move_over_survivors(survivors, chromosomes, new_chromosome)
-        for i_mp in range(int(pop_size/2)):
-            new_chromosome[i_mp] = chromosomes[int(survivors[i_mp][1])][:]
+        new_chromosome = _move_over_survivors(pop_size, survivors, chromosomes, new_chromosome)
+        #for i_mp in range(int(pop_size/2)):
+        #    new_chromosome[i_mp] = chromosomes[int(survivors[i_mp][1])][:]
         mating_pairs = choose_mating_pairs(survivors, pop_size)
         # Generate children
+#        new_chromosome = _generate_children(pop_size, n_sp, i_n_new, mating_pairs, chromosomes, new_chromosome)
         for i_mp in range(int(pop_size/4)):
             i_mate1_idx = mating_pairs[i_mp][0]
             i_mate2_idx = mating_pairs[i_mp][1]
@@ -53,7 +54,29 @@ def _fill_fitness_idxs(pop_size, fitnesses, fitnesses_idxs):
         fitnesses_idxs[i_mp][0] = fitnesses[i_mp]
         fitnesses_idxs[i_mp][1] = i_mp
 
+@numba.njit(cache=True)
+def _move_over_survivors(pop_size, survivors, chromosomes, new_chromosome):
+    for i_mp in range(int(pop_size/2)):
+        new_chromosome[i_mp] = chromosomes[int(survivors[i_mp][1])][:]
+    return new_chromosome
 
+#@numba.njit(cache=True)
+#def _generate_children(pop_size, n_sp, i_n_new, mating_pairs, chromosomes, new_chromosome):
+#
+#    for i_mp in range(int(pop_size/4)):
+#        i_mate1_idx = mating_pairs[i_mp][0]
+#        i_mate2_idx = mating_pairs[i_mp][1]
+#        chromosome1 = chromosomes[i_mate1_idx,:]
+#        chromosome2 = chromosomes[i_mate2_idx,:]
+#        # Crossover and update the chromosomes
+#        children = crossover(chromosome1, chromosome2, n_sp)
+#        child1 = children[0,:]
+#        child2 = children[1, :]
+#        new_chromosome[i_n_new] = child1
+#        i_n_new = i_n_new + 1
+#        new_chromosome[i_n_new] = child2
+#        i_n_new = i_n_new + 1
+#    return new_chromosome
 
 @numba.njit(cache=True)
 def random_population(pop_size, n_sp,

--- a/galibrate/run_gao_numba.py
+++ b/galibrate/run_gao_numba.py
@@ -64,7 +64,7 @@ def _fill_fitness_idxs(pop_size, fitnesses, fitnesses_idxs):
     for i_mp in range(pop_size):
         fitnesses_idxs[i_mp][0] = fitnesses[i_mp]
         fitnesses_idxs[i_mp][1] = i_mp
-    return fitnesses_idxs    
+    return fitnesses_idxs
 
 @numba.njit(cache=True)
 def _move_over_survivors(pop_size, survivors, chromosomes, new_chromosome):

--- a/galibrate/run_gao_numba.py
+++ b/galibrate/run_gao_numba.py
@@ -37,20 +37,20 @@ def run_gao(pop_size, n_sp, locs, widths, n_gen,
         #    new_chromosome[i_mp] = chromosomes[int(survivors[i_mp][1])][:]
         mating_pairs = choose_mating_pairs(survivors, pop_size)
         # Generate children
-#        new_chromosome = _generate_children(pop_size, n_sp, i_n_new, mating_pairs, chromosomes, new_chromosome)
-        for i_mp in range(int(pop_size/4)):
-            i_mate1_idx = mating_pairs[i_mp][0]
-            i_mate2_idx = mating_pairs[i_mp][1]
-            chromosome1 = chromosomes[i_mate1_idx,:]
-            chromosome2 = chromosomes[i_mate2_idx,:]
-            # Crossover and update the chromosomes
-            children = crossover(chromosome1, chromosome2, n_sp)
-            child1 = children[0,:]
-            child2 = children[1, :]
-            new_chromosome[i_n_new] = child1
-            i_n_new = i_n_new + 1
-            new_chromosome[i_n_new] = child2
-            i_n_new = i_n_new + 1
+        new_chromosome = _generate_children(pop_size, n_sp, i_n_new, mating_pairs, chromosomes, new_chromosome)
+#        for i_mp in range(int(pop_size/4)):
+#            i_mate1_idx = mating_pairs[i_mp][0]
+#            i_mate2_idx = mating_pairs[i_mp][1]
+#            chromosome1 = chromosomes[i_mate1_idx,:]
+#            chromosome2 = chromosomes[i_mate2_idx,:]
+#            # Crossover and update the chromosomes
+#            children = crossover(chromosome1, chromosome2, n_sp)
+#            child1 = children[0,:]
+#            child2 = children[1, :]
+#            new_chromosome[i_n_new] = child1
+#            i_n_new = i_n_new + 1
+#            new_chromosome[i_n_new] = child2
+#            i_n_new = i_n_new + 1
         # Replace the old population with the new one
         chromosomes = new_chromosome.copy()
         # Mutation
@@ -84,23 +84,23 @@ def _copy_survivor_fitnesses(pop_size, survivors, fitness_array):
         fitness_array[i] = survivors[i][0]
     return fitness_array
 
-#@numba.njit(cache=True)
-#def _generate_children(pop_size, n_sp, i_n_new, mating_pairs, chromosomes, new_chromosome):
-#
-#    for i_mp in range(int(pop_size/4)):
-#        i_mate1_idx = mating_pairs[i_mp][0]
-#        i_mate2_idx = mating_pairs[i_mp][1]
-#        chromosome1 = chromosomes[i_mate1_idx,:]
-#        chromosome2 = chromosomes[i_mate2_idx,:]
-#        # Crossover and update the chromosomes
-#        children = crossover(chromosome1, chromosome2, n_sp)
-#        child1 = children[0,:]
-#        child2 = children[1, :]
-#        new_chromosome[i_n_new] = child1
-#        i_n_new = i_n_new + 1
-#        new_chromosome[i_n_new] = child2
-#        i_n_new = i_n_new + 1
-#    return new_chromosome
+@numba.njit(cache=True)
+def _generate_children(pop_size, n_sp, i_n_new, mating_pairs, chromosomes, new_chromosome):
+
+    for i_mp in range(int(pop_size/4)):
+        i_mate1_idx = mating_pairs[i_mp][0]
+        i_mate2_idx = mating_pairs[i_mp][1]
+        chromosome1 = chromosomes[i_mate1_idx,:]
+        chromosome2 = chromosomes[i_mate2_idx,:]
+        # Crossover and update the chromosomes
+        children = crossover(chromosome1, chromosome2, n_sp)
+        child1 = children[0,:]
+        child2 = children[1, :]
+        new_chromosome[i_n_new] = child1
+        i_n_new = i_n_new + 1
+        new_chromosome[i_n_new] = child2
+        i_n_new = i_n_new + 1
+    return new_chromosome
 
 @numba.njit(cache=True)
 def random_population(pop_size, n_sp,

--- a/galibrate/run_gao_numba.py
+++ b/galibrate/run_gao_numba.py
@@ -26,7 +26,7 @@ def run_gao(pop_size, n_sp, locs, widths, n_gen,
             fitnesses = _compute_fitnesses(fitness_func, chromosomes, pop_size, i_n_new, fitnesses)
 
         fitnesses_idxs = np.zeros((pop_size, 2), dtype=np.double)
-        fitnesses_idex = _fill_fitness_idxs(pop_size, fitnesses, fitnesses_idxs)
+        fitnesses_idxs = _fill_fitness_idxs(pop_size, fitnesses, fitnesses_idxs)
 
         # Selection
         fitnesses_idxs_sort = np.sort(fitnesses_idxs, axis=0)
@@ -64,6 +64,7 @@ def _fill_fitness_idxs(pop_size, fitnesses, fitnesses_idxs):
     for i_mp in range(pop_size):
         fitnesses_idxs[i_mp][0] = fitnesses[i_mp]
         fitnesses_idxs[i_mp][1] = i_mp
+    return fitnesses_idxs    
 
 @numba.njit(cache=True)
 def _move_over_survivors(pop_size, survivors, chromosomes, new_chromosome):


### PR DESCRIPTION
In the run_gao_numba module I've ported several code blocks from the run_gao function to functions, most of which are decorated with numba.njit decorators. I also made an improvement to remove duplicate computes of the fitness for survivors from the previous generation.  

These changes roughly doubled the execution speed of the Numba optimized version of the GA core. 

Improvements in a non-public core module:  increment version number 0.2.0 -> 0.3.0 