### PR TITLE
Improve cython version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Python version badge](https://img.shields.io/badge/python-3.6,3.7-blue.svg)
 [![license](https://img.shields.io/github/license/blakeaw/GAlibrate.svg)](LICENSE)
-![version](https://img.shields.io/badge/version-0.3.0-orange.svg)
+![version](https://img.shields.io/badge/version-0.4.0-orange.svg)
 [![release](https://img.shields.io/github/release-pre/blakeaw/GAlibrate.svg)](https://github.com/blakeaw/GAlibrate/releases/tag/v0.2.0)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/6cdd91c06b11458384becb85db9adb15)](https://www.codacy.com/app/blakeaw1102/GAlibrate?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=blakeaw/GAlibrate&amp;utm_campaign=Badge_Grade)
 [![DOI](https://zenodo.org/badge/197295657.svg)](https://zenodo.org/badge/latestdoi/197295657)

--- a/galibrate/run_gao_cython.pyx
+++ b/galibrate/run_gao_cython.pyx
@@ -39,8 +39,9 @@ def run_gao(int pop_size, int n_sp, np.ndarray[np.double_t, ndim=1] locs,
         fitnesses_idxs_sort = np.sort(fitnesses_idxs, axis=0)
         survivors = fitnesses_idxs_sort[pop_size/2:]
         # Move over the survivors
-        for i_mp in range(pop_size/2):
-            new_chromosome[i_mp] = chromosomes[int(survivors[i_mp][1])][:]
+        _move_over_survivors(pop_size, survivors, chromosomes, new_chromosome)
+        #for i_mp in range(pop_size/2):
+        #    new_chromosome[i_mp] = chromosomes[int(survivors[i_mp][1])][:]
         mating_pairs = choose_mating_pairs(survivors, pop_size)
         # Generate children
         for i_mp in range(pop_size/4):
@@ -73,6 +74,17 @@ cdef void _fill_fitness_idxs(int pop_size, double[:] fitnesses,
     for i_mp in range(pop_size):
         fitnesses_idxs[i_mp][0] = fitnesses[i_mp]
         fitnesses_idxs[i_mp][1] = i_mp
+    return
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+@cython.cdivision(True)
+cdef void _move_over_survivors(int pop_size, double[:,:] survivors,
+                               double[:,:] chromosomes,
+                               double[:,:] new_chromosome):
+    cdef int i_mp
+    for i_mp in range(pop_size/2):
+        new_chromosome[i_mp] = chromosomes[<int>survivors[i_mp][1]][:]
     return
 
 def _compute_fitnesses(fitness_func, chromosomes, pop_size, start, fitness_array):

--- a/galibrate/run_gao_cython.pyx
+++ b/galibrate/run_gao_cython.pyx
@@ -44,19 +44,20 @@ def run_gao(int pop_size, int n_sp, np.ndarray[np.double_t, ndim=1] locs,
         #    new_chromosome[i_mp] = chromosomes[int(survivors[i_mp][1])][:]
         mating_pairs = choose_mating_pairs(survivors, pop_size)
         # Generate children
-        for i_mp in range(pop_size/4):
-            i_mate1_idx = mating_pairs[i_mp][0]
-            i_mate2_idx = mating_pairs[i_mp][1]
-            chromosome1 = chromosomes[i_mate1_idx,:]
-            chromosome2 = chromosomes[i_mate2_idx,:]
-            # Crossover and update the chromosomes
-            children = crossover(chromosome1, chromosome2, n_sp)
-            child1 = children[0,:]
-            child2 = children[1, :]
-            new_chromosome[i_n_new] = child1
-            i_n_new = i_n_new + 1
-            new_chromosome[i_n_new] = child2
-            i_n_new = i_n_new + 1
+        _generate_children(pop_size, n_sp, i_n_new, mating_pairs, chromosomes, new_chromosome)
+#        for i_mp in range(pop_size/4):
+#            i_mate1_idx = mating_pairs[i_mp][0]
+#            i_mate2_idx = mating_pairs[i_mp][1]
+#            chromosome1 = chromosomes[i_mate1_idx,:]
+#            chromosome2 = chromosomes[i_mate2_idx,:]
+#            # Crossover and update the chromosomes
+#            children = crossover(chromosome1, chromosome2, n_sp)
+#            child1 = children[0,:]
+#            child2 = children[1, :]
+#            new_chromosome[i_n_new] = child1
+#            i_n_new = i_n_new + 1
+#            new_chromosome[i_n_new] = child2
+#            i_n_new = i_n_new + 1
         # Replace the old population with the new one
         #chromosomes = new_chromosome.copy()
         double_deepcopy_2d(chromosomes, new_chromosome, pop_size, n_sp)
@@ -70,7 +71,7 @@ def run_gao(int pop_size, int n_sp, np.ndarray[np.double_t, ndim=1] locs,
 @cython.wraparound(False)
 cdef void _fill_fitness_idxs(int pop_size, double[:] fitnesses,
                              double[:,:] fitnesses_idxs):
-    cdef int i_mp
+    cdef Py_ssize_t i_mp
     for i_mp in range(pop_size):
         fitnesses_idxs[i_mp][0] = fitnesses[i_mp]
         fitnesses_idxs[i_mp][1] = i_mp
@@ -82,7 +83,7 @@ cdef void _fill_fitness_idxs(int pop_size, double[:] fitnesses,
 cdef void _move_over_survivors(int pop_size, double[:,:] survivors,
                                double[:,:] chromosomes,
                                double[:,:] new_chromosome):
-    cdef int i_mp
+    cdef Py_ssize_t i_mp
     for i_mp in range(pop_size/2):
         new_chromosome[i_mp] = chromosomes[<int>survivors[i_mp][1]][:]
     return
@@ -97,10 +98,38 @@ def _compute_fitnesses(fitness_func, chromosomes, pop_size, start, fitness_array
 @cython.cdivision(True)
 cdef void _copy_survivor_fitnesses(int pop_size, double[:,:] survivors,
                                    double[:] fitness_array):
-    cdef int stop = int(pop_size/2)
-    cdef int i
+    cdef int stop = pop_size/2
+    cdef Py_ssize_t i
     for i in range(0, stop):
         fitness_array[i] = survivors[i][0]
+    return
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+@cython.cdivision(True)
+cdef void _generate_children(int pop_size, int n_sp, int i_n_new,
+                             long[:,:] mating_pairs, double[:,:] chromosomes,
+                             double[:,:] new_chromosome):
+    cdef Py_ssize_t i_mp, i_mate1_idx, i_mate2_idx
+    cdef double[:] chromosome1
+    cdef double[:] chromosome2
+    cdef double[:] child1
+    cdef double[:] child2
+    cdef double[:,:] children
+
+    for i_mp in range(pop_size/4):
+        i_mate1_idx = mating_pairs[i_mp][0]
+        i_mate2_idx = mating_pairs[i_mp][1]
+        chromosome1 = chromosomes[i_mate1_idx,:]
+        chromosome2 = chromosomes[i_mate2_idx,:]
+        # Crossover and update the chromosomes
+        children = crossover(chromosome1, chromosome2, n_sp)
+        child1 = children[0,:]
+        child2 = children[1, :]
+        new_chromosome[i_n_new] = child1
+        i_n_new = i_n_new + 1
+        new_chromosome[i_n_new] = child2
+        i_n_new = i_n_new + 1
     return
 
 @cython.boundscheck(False)

--- a/galibrate/run_gao_cython.pyx
+++ b/galibrate/run_gao_cython.pyx
@@ -31,9 +31,10 @@ def run_gao(int pop_size, int n_sp, np.ndarray[np.double_t, ndim=1] locs,
             fitnesses = _compute_fitnesses(fitness_func, chromosomes, pop_size, i_n_new, fitnesses)
 
         fitnesses_idxs = np.zeros([pop_size, 2], dtype=np.double)
-        for i_mp in range(pop_size):
-            fitnesses_idxs[i_mp][0] = fitnesses[i_mp]
-            fitnesses_idxs[i_mp][1] = i_mp
+        _fill_fitness_idxs(pop_size, fitnesses, fitnesses_idxs)
+        #for i_mp in range(pop_size):
+        #    fitnesses_idxs[i_mp][0] = fitnesses[i_mp]
+        #    fitnesses_idxs[i_mp][1] = i_mp
         # Selection
         fitnesses_idxs_sort = np.sort(fitnesses_idxs, axis=0)
         survivors = fitnesses_idxs_sort[pop_size/2:]
@@ -64,6 +65,16 @@ def run_gao(int pop_size, int n_sp, np.ndarray[np.double_t, ndim=1] locs,
         _copy_survivor_fitnesses(pop_size, survivors, fitnesses)
     return chromosomes
 
+@cython.boundscheck(False)
+@cython.wraparound(False)
+cdef void _fill_fitness_idxs(int pop_size, double[:] fitnesses,
+                             double[:,:] fitnesses_idxs):
+    cdef int i_mp
+    for i_mp in range(pop_size):
+        fitnesses_idxs[i_mp][0] = fitnesses[i_mp]
+        fitnesses_idxs[i_mp][1] = i_mp
+    return
+
 def _compute_fitnesses(fitness_func, chromosomes, pop_size, start, fitness_array):
     for i in range(start, pop_size):
         fitness_array[i] = fitness_func(chromosomes[i])
@@ -75,6 +86,7 @@ def _compute_fitnesses(fitness_func, chromosomes, pop_size, start, fitness_array
 cdef void _copy_survivor_fitnesses(int pop_size, double[:,:] survivors,
                                    double[:] fitness_array):
     cdef int stop = int(pop_size/2)
+    cdef int i
     for i in range(0, stop):
         fitness_array[i] = survivors[i][0]
     return


### PR DESCRIPTION
As in the Numba version of core algorithm, in the run_gao_cython version I ported out several code blocks that contained loops to cdef functions that can be more effectively compiled. Similarily again, I also fixed it so that the fitness of survivors from a previous generation is not recomputed. These changes improved the code speed by about 50% for a 1000 parameter, 5000 population size, and 1000 generation test problem. 

Changes to the non-public core: Increment minor version: 0.3.0 -> 0.4.0